### PR TITLE
go/ir: fix panic since go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        go: ["1.21.x"]
+        go: ["1.22.x"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: WillAbides/setup-go-faster@v1.12.0
       with:
-        go-version: "1.20.x"
+        go-version: "1.22.x"
     # this downloads all artifacts of the current workflow into the current working directory, creating one directory per artifact
     - uses: actions/download-artifact@v3
     - id: glob

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module honnef.co/go/tools
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/go/ir/sanity.go
+++ b/go/ir/sanity.go
@@ -107,7 +107,7 @@ func (s *sanity) checkInstr(idx int, instr Instruction) {
 		} else {
 			prev := s.block.Instrs[idx-1]
 			switch prev.(type) {
-			case *Phi, *Sigma:
+			case *Phi, *Sigma, *Load, *Store:
 			default:
 				s.errorf("Phi instruction follows a non-Phi, non-Sigma: %T", prev)
 			}


### PR DESCRIPTION
## Minimal reproducible example

```bash
go test go/ir/stdlib_test.go
```

<summary>errors</summary>
<details>

```
> go test go/ir/stdlib_test.go
Error: function runtime.exitsyscall, block 11: Phi instruction follows a non-Phi, non-Sigma: *ir.Store
# Name: runtime.exitsyscall
# Package: runtime
# Location: /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/runtime/proc.go:4502:1
func exitsyscall():
b0: # entry
        t1 = Const <int32> {1}
        t2 = Const <string> {"exitsyscall: sysc..."}
        t3 = Const <int64> {0}
        t4 = Const <puintptr> {0}
        t5 = Const <bool> {true}
        t6 = Const <uint32> {1}
        t7 = Const <uint32> {3}
        t8 = Const <uint32> {2}
        t9 = Const <uintptr> {0}
        t10 = Const <int32> {1}
        t11 = Const <uintptr> {18446744073709550302}
        t12 = Const <uintptr> {928}
        t13 = Const <bool> {false}
        t14 = Const <untyped bool> {true}
        t15 = Const <int32> {1}
        t16 = Const <uintptr> {0}
        t17 = Const <uint32> {1}
        t18 = Const <bool> {false}
        t19 = Const <*m> {nil}
        t20 = Const <uintptr> {0}
        t21 = Const <*m> {nil}
        t22 = Const <uintptr> {0}
        t23 = AggregateConst <traceLocker> (t19, t20)
        t24 = AggregateConst <traceLocker> (t21, t22)
        t25 = HeapAlloc <**g> # split alloc
        ; func runtime.getg() *runtime.g @ 4503:8 is getg
        t27 = Call <*g> getg
        ; *ast.CallExpr @ 4503:8 is t27
        ; var gp *runtime.g @ 4503:2 is t27
        ; var gp *runtime.g @ 4505:2 is t27
        t31 = FieldAddr <**m> [5] (m) t27
        ; address of field m *runtime.m @ 4505:5 is t31
        t33 = Load <*m> t31
        ; *ast.SelectorExpr @ 4505:2 is t33
        t35 = FieldAddr <*int32> [19] (locks) t33
        ; address of field locks int32 @ 4505:7 is t35
        t37 = Load <int32> t35
        t38 = BinOp <int32> {+} t37 t1
        Store {int32} t35 t38
        ; field locks int32 @ 4505:7 is t38
        ; func runtime.getcallersp() uintptr @ 4506:5 is getcallersp
        t42 = Call <uintptr> getcallersp
        ; *ast.CallExpr @ 4506:5 is t42
        ; var gp *runtime.g @ 4506:21 is t27
        t45 = FieldAddr <*uintptr> [7] (syscallsp) t27
        ; address of field syscallsp uintptr @ 4506:24 is t45
        t47 = Load <uintptr> t45
        ; *ast.SelectorExpr @ 4506:21 is t47
        t49 = BinOp <bool> {>} t42 t47
        ; *ast.BinaryExpr @ 4506:5 is t49
        If t49 → b2 b3

b1: ← b15 b20 b18 b17 b2 # exit
        Return

b2: ← b0 # if.then
        t53 = Sigma <*g> [b0] t27
        ; func runtime.throw(s string) @ 4507:3 is throw
        t55 = Call <()> throw t2
        Store {*runtime.g} t25 t53 # split alloc
        Unreachable → b1

b3: ← b0 # if.done
        t58 = Sigma <*g> [b0] t27
        ; var gp *runtime.g @ 4510:2 is t58
        t60 = FieldAddr <*int64> [15] (waitsince) t58
        ; address of field waitsince int64 @ 4510:5 is t60
        Store {int64} t60 t3
        ; field waitsince int64 @ 4510:5 is t3
        ; var gp *runtime.g @ 4511:10 is t58
        t65 = FieldAddr <**m> [5] (m) t58
        ; address of field m *runtime.m @ 4511:13 is t65
        t67 = Load <*m> t65
        ; *ast.SelectorExpr @ 4511:10 is t67
        t69 = FieldAddr <*puintptr> [14] (oldp) t67
        ; address of field oldp runtime.puintptr @ 4511:15 is t69
        t71 = Load <puintptr> t69
        ; *ast.SelectorExpr @ 4511:10 is t71
        t73 = Call <*p> (puintptr).ptr t71
        ; *ast.CallExpr @ 4511:10 is t73
        ; var oldp *runtime.p @ 4511:2 is t73
        ; var gp *runtime.g @ 4512:2 is t58
        t77 = FieldAddr <**m> [5] (m) t58
        ; address of field m *runtime.m @ 4512:5 is t77
        t79 = Load <*m> t77
        ; *ast.SelectorExpr @ 4512:2 is t79
        t81 = FieldAddr <*puintptr> [14] (oldp) t79
        ; address of field oldp runtime.puintptr @ 4512:7 is t81
        Store {runtime.puintptr} t81 t4
        ; field oldp runtime.puintptr @ 4512:7 is t4
        ; func runtime.exitsyscallfast(oldp *runtime.p) bool @ 4513:5 is exitsyscallfast
        ; var oldp *runtime.p @ 4513:21 is t73
        t87 = Call <bool> exitsyscallfast t73
        ; *ast.CallExpr @ 4513:5 is t87
        If t87 → b4 b5

b4: ← b3 # if.then
        t90 = Sigma <*g> [b3] t58
        t91 = Sigma <*p> [b3] t73
        ; address of var runtime.goroutineProfile struct{sema uint32; active bool; offset runtime/internal/atomic.Int6
        t93 = FieldAddr <*bool> [1] (active) goroutineProfile
        ; address of field active bool @ 4516:23 is t93
        t95 = Load <bool> t93
        ; *ast.SelectorExpr @ 4516:6 is t95
        Store {*runtime.g} t25 t90 # split alloc
        If t95 → b6 b7

b5: ← b3 # if.done
        t99 = Sigma <*g> [b3] t58
        t100 = Sigma <*p> [b3] t73
        If t14 → b20 b19

b6: ← b4 # if.then
        t102 = Sigma <*g> [b4] t90
        Store {*runtime.g} t25 t102 # split alloc
        ; func runtime.systemstack(fn func()) @ 4520:4 is systemstack
        t105 = MakeClosure <func()> exitsyscall$1 t25
        ; *ast.FuncLit @ 4520:16 is t105
        t107 = Call <()> systemstack t105
        ; *ast.CallExpr @ 4520:4 is t107
        Jump → b7

b7: ← b4 b6 # if.done
        t110 = HeapAlloc <*traceLocker> # split alloc
        ; func runtime.traceAcquire() runtime.traceLocker @ 4524:12 is traceAcquire
        t112 = Call <traceLocker> traceAcquire
        ; *ast.CallExpr @ 4524:12 is t112
        ; var trace runtime.traceLocker @ 4524:3 is t112
        ; var trace runtime.traceLocker @ 4525:6 is t112
        t116 = Call <bool> (traceLocker).ok t112
        ; *ast.CallExpr @ 4525:6 is t116
        Store {runtime.traceLocker} t110 t112 # split alloc
        If t116 → b8 b9

b8: ← b7 # if.then
        t120 = Sigma <*p> [b7] t91
        t121 = Sigma <traceLocker> [b7] t112
        t122 = HeapAlloc <*bool>
        ; var oldp *runtime.p @ 4526:13 is t120
        t124 = Load <*g> t25
        ; var gp *runtime.g @ 4526:21 is t124
        t126 = FieldAddr <**m> [5] (m) t124
        ; address of field m *runtime.m @ 4526:24 is t126
        t128 = Load <*m> t126
        ; *ast.SelectorExpr @ 4526:21 is t128
        t130 = FieldAddr <*puintptr> [12] (p) t128
        ; address of field p runtime.puintptr @ 4526:26 is t130
        t132 = Load <puintptr> t130
        ; *ast.SelectorExpr @ 4526:21 is t132
        t134 = Call <*p> (puintptr).ptr t132
        ; *ast.CallExpr @ 4526:21 is t134
        t136 = BinOp <bool> {!=} t120 t134
        ; *ast.BinaryExpr @ 4526:13 is t136
        If t136 → b11 b10

b9: ← b7 b11 # if.done
        t139 = Load <*g> t25
        ; var gp *runtime.g @ 4545:3 is t139
        t141 = FieldAddr <**m> [5] (m) t139
        ; address of field m *runtime.m @ 4545:6 is t141
        t143 = Load <*m> t141
        ; *ast.SelectorExpr @ 4545:3 is t143
        t145 = FieldAddr <*puintptr> [12] (p) t143
        ; address of field p runtime.puintptr @ 4545:8 is t145
        t147 = Load <puintptr> t145
        ; *ast.SelectorExpr @ 4545:3 is t147
        t149 = Call <*p> (puintptr).ptr t147
        ; *ast.CallExpr @ 4545:3 is t149
        t151 = FieldAddr <*uint32> [4] (syscalltick) t149
        ; address of field syscalltick uint32 @ 4545:16 is t151
        t153 = Load <uint32> t151
        t154 = BinOp <uint32> {+} t153 t6
        Store {uint32} t151 t154
        ; field syscalltick uint32 @ 4545:16 is t154
        ; func runtime.casgstatus(gp *runtime.g, oldval uint32, newval uint32) @ 4547:3 is casgstatus
        t158 = Load <*g> t25
        ; var gp *runtime.g @ 4547:14 is t158
        t160 = Call <()> casgstatus t158 t7 t8
        ; *ast.CallExpr @ 4547:3 is t160
        t162 = Load <traceLocker> t110
        ; var trace runtime.traceLocker @ 4548:6 is t162
        t164 = Call <bool> (traceLocker).ok t162
        ; *ast.CallExpr @ 4548:6 is t164
        If t164 → b12 b13

b10: ← b8 # binop.rhs
        t167 = Load <*g> t25
        ; var gp *runtime.g @ 4526:37 is t167
        t169 = FieldAddr <**m> [5] (m) t167
        ; address of field m *runtime.m @ 4526:40 is t169
        t171 = Load <*m> t169
        ; *ast.SelectorExpr @ 4526:37 is t171
        t173 = FieldAddr <*uint32> [50] (syscalltick) t171
        ; address of field syscalltick uint32 @ 4526:42 is t173
        t175 = Load <uint32> t173
        ; *ast.SelectorExpr @ 4526:37 is t175
        t177 = Load <*g> t25
        ; var gp *runtime.g @ 4526:57 is t177
        t179 = FieldAddr <**m> [5] (m) t177
        ; address of field m *runtime.m @ 4526:60 is t179
        t181 = Load <*m> t179
        ; *ast.SelectorExpr @ 4526:57 is t181
        t183 = FieldAddr <*puintptr> [12] (p) t181
        ; address of field p runtime.puintptr @ 4526:62 is t183
        t185 = Load <puintptr> t183
        ; *ast.SelectorExpr @ 4526:57 is t185
        t187 = Call <*p> (puintptr).ptr t185
        ; *ast.CallExpr @ 4526:57 is t187
        t189 = FieldAddr <*uint32> [4] (syscalltick) t187
        ; address of field syscalltick uint32 @ 4526:70 is t189
        t191 = Load <uint32> t189
        ; *ast.SelectorExpr @ 4526:57 is t191
        t193 = BinOp <bool> {!=} t175 t191
        ; *ast.BinaryExpr @ 4526:37 is t193
        Jump → b11

b11: ← b8 b10 # binop.done
        Store {runtime.traceLocker} t110 t121 # split alloc
        t197 = Phi <bool> 8:t5 10:t193
        ; *ast.BinaryExpr @ 4526:13 is t197
        Store {bool} t122 t197
        ; var lostP bool @ 4526:4 is t197
        ; func runtime.systemstack(fn func()) @ 4527:4 is systemstack
        t202 = MakeClosure <func()> exitsyscall$2 t110 t122
        ; *ast.FuncLit @ 4527:16 is t202
        t204 = Call <()> systemstack t202
        ; *ast.CallExpr @ 4527:4 is t204
        Jump → b9

b12: ← b9 # if.then
        ; func runtime.traceRelease(tl runtime.traceLocker) @ 4549:4 is traceRelease
        t208 = Load <traceLocker> t110
        ; var trace runtime.traceLocker @ 4549:17 is t208
        t210 = Call <()> traceRelease t208
        ; *ast.CallExpr @ 4549:4 is t210
        Jump → b13

b13: ← b9 b12 # if.done
        t213 = Load <*g> t25
        ; var gp *runtime.g @ 4554:3 is t213
        t215 = FieldAddr <*uintptr> [7] (syscallsp) t213
        ; address of field syscallsp uintptr @ 4554:6 is t215
        Store {uintptr} t215 t9
        ; field syscallsp uintptr @ 4554:6 is t9
        t219 = Load <*g> t25
        ; var gp *runtime.g @ 4555:3 is t219
        t221 = FieldAddr <**m> [5] (m) t219
        ; address of field m *runtime.m @ 4555:6 is t221
        t223 = Load <*m> t221
        ; *ast.SelectorExpr @ 4555:3 is t223
        t225 = FieldAddr <*int32> [19] (locks) t223
        ; address of field locks int32 @ 4555:8 is t225
        t227 = Load <int32> t225
        t228 = BinOp <int32> {-} t227 t10
        Store {int32} t225 t228
        ; field locks int32 @ 4555:8 is t228
        t231 = Load <*g> t25
        ; var gp *runtime.g @ 4556:6 is t231
        t233 = FieldAddr <*bool> [17] (preempt) t231
        ; address of field preempt bool @ 4556:9 is t233
        t235 = Load <bool> t233
        ; *ast.SelectorExpr @ 4556:6 is t235
        If t235 → b14 b16

b14: ← b13 # if.then
        t238 = Load <*g> t25
        ; var gp *runtime.g @ 4558:4 is t238
        t240 = FieldAddr <*uintptr> [1] (stackguard0) t238
        ; address of field stackguard0 uintptr @ 4558:7 is t240
        Store {uintptr} t240 t11
        ; field stackguard0 uintptr @ 4558:7 is t11
        Jump → b15

b15: ← b14 b16 # if.done
        t245 = Load <*g> t25
        ; var gp *runtime.g @ 4563:3 is t245
        t247 = FieldAddr <*bool> [23] (throwsplit) t245
        ; address of field throwsplit bool @ 4563:6 is t247
        Store {bool} t247 t13
        ; field throwsplit bool @ 4563:6 is t13
        ; address of var runtime.sched runtime.schedt @ 4565:6 is sched
        t252 = FieldAddr <*struct{user bool; runnable gQueue; n int32}> [18] (disable) sched
        ; address of field disable struct{user bool; runnable runtime.gQueue; n int32} @ 4565:12 is t252
        ; address of field disable struct{user bool; runnable runtime.gQueue; n int32} @ 4565:12 is t252
        t255 = FieldAddr <*bool> [0] (user) t252
        ; address of field user bool @ 4565:20 is t255
        t257 = Load <bool> t255
        ; *ast.SelectorExpr @ 4565:6 is t257
        If t257 → b18 b1

b16: ← b13 # if.else
        t260 = Load <*g> t25
        ; var gp *runtime.g @ 4561:4 is t260
        t262 = FieldAddr <*uintptr> [1] (stackguard0) t260
        ; address of field stackguard0 uintptr @ 4561:7 is t262
        t264 = Load <*g> t25
        ; var gp *runtime.g @ 4561:21 is t264
        t266 = FieldAddr <*stack> [0] (stack) t264
        ; address of field stack runtime.stack @ 4561:24 is t266
        ; address of field stack runtime.stack @ 4561:24 is t266
        t269 = FieldAddr <*uintptr> [0] (lo) t266
        ; address of field lo uintptr @ 4561:30 is t269
        t271 = Load <uintptr> t269
        ; *ast.SelectorExpr @ 4561:21 is t271
        t273 = BinOp <uintptr> {+} t271 t12
        ; *ast.BinaryExpr @ 4561:21 is t273
        Store {uintptr} t262 t273
        ; field stackguard0 uintptr @ 4561:7 is t273
        Jump → b15

b17: ← b18 # if.then
        ; func runtime.Gosched() @ 4567:4 is Gosched
        t279 = Call <()> Gosched
        ; *ast.CallExpr @ 4567:4 is t279
        Jump → b1

b18: ← b15 # cond.true
        ; func runtime.schedEnabled(gp *runtime.g) bool @ 4565:29 is schedEnabled
        t283 = Load <*g> t25
        ; var gp *runtime.g @ 4565:42 is t283
        t285 = Call <bool> schedEnabled t283
        ; *ast.CallExpr @ 4565:29 is t285
        If t285 → b1 b17

b19: ← b5 # if.then
        t288 = Sigma <*g> [b5] t99
        t289 = Sigma <*p> [b5] t100
        ; func runtime.traceAcquire() runtime.traceLocker @ 4577:12 is traceAcquire
        t291 = Call <traceLocker> traceAcquire
        ; *ast.CallExpr @ 4577:12 is t291
        ; var trace runtime.traceLocker @ 4577:3 is t291
        ; var trace runtime.traceLocker @ 4578:6 is t291
        t295 = Call <bool> (traceLocker).ok t291
        ; *ast.CallExpr @ 4578:6 is t295
        If t295 → b21 b20

b20: ← b5 b19 b21 # if.done
        t298 = Sigma <*g> [b5] t99
        t299 = Sigma <*g> [b19] t288
        t300 = Phi <*runtime.g> 5:t298 19:t299 21:t345
        ; var gp *runtime.g @ 4584:2 is t300
        t302 = FieldAddr <**m> [5] (m) t300
        ; address of field m *runtime.m @ 4584:5 is t302
        t304 = Load <*m> t302
        ; *ast.SelectorExpr @ 4584:2 is t304
        t306 = FieldAddr <*int32> [19] (locks) t304
        ; address of field locks int32 @ 4584:7 is t306
        t308 = Load <int32> t306
        t309 = BinOp <int32> {-} t308 t15
        Store {int32} t306 t309
        ; field locks int32 @ 4584:7 is t309
        ; func runtime.mcall(fn func(*runtime.g)) @ 4587:2 is mcall
        ; func runtime.exitsyscall0(gp *runtime.g) @ 4587:8 is exitsyscall0
        t314 = Call <()> mcall exitsyscall0
        ; *ast.CallExpr @ 4587:2 is t314
        ; var gp *runtime.g @ 4595:2 is t300
        t317 = FieldAddr <*uintptr> [7] (syscallsp) t300
        ; address of field syscallsp uintptr @ 4595:5 is t317
        Store {uintptr} t317 t16
        ; field syscallsp uintptr @ 4595:5 is t16
        ; var gp *runtime.g @ 4596:2 is t300
        t322 = FieldAddr <**m> [5] (m) t300
        ; address of field m *runtime.m @ 4596:5 is t322
        t324 = Load <*m> t322
        ; *ast.SelectorExpr @ 4596:2 is t324
        t326 = FieldAddr <*puintptr> [12] (p) t324
        ; address of field p runtime.puintptr @ 4596:7 is t326
        t328 = Load <puintptr> t326
        ; *ast.SelectorExpr @ 4596:2 is t328
        t330 = Call <*p> (puintptr).ptr t328
        ; *ast.CallExpr @ 4596:2 is t330
        t332 = FieldAddr <*uint32> [4] (syscalltick) t330
        ; address of field syscalltick uint32 @ 4596:15 is t332
        t334 = Load <uint32> t332
        t335 = BinOp <uint32> {+} t334 t17
        Store {uint32} t332 t335
        ; field syscalltick uint32 @ 4596:15 is t335
        ; var gp *runtime.g @ 4597:2 is t300
        t339 = FieldAddr <*bool> [23] (throwsplit) t300
        ; address of field throwsplit bool @ 4597:5 is t339
        Store {bool} t339 t18
        ; field throwsplit bool @ 4597:5 is t18
        Store {*runtime.g} t25 t300 # split alloc
        Jump → b1

b21: ← b19 # if.then
        t345 = Sigma <*g> [b19] t288
        t346 = Sigma <*p> [b19] t289
        t347 = Sigma <traceLocker> [b19] t291
        ; var trace runtime.traceLocker @ 4579:4 is t347
        ; var gp *runtime.g @ 4579:34 is t345
        ; var oldp *runtime.p @ 4579:38 is t346
        t351 = Call <()> (traceLocker).RecordSyscallExitedTime t347 t345 t346
        ; *ast.CallExpr @ 4579:4 is t351
        ; func runtime.traceRelease(tl runtime.traceLocker) @ 4580:4 is traceRelease
        ; var trace runtime.traceLocker @ 4580:17 is t347
        t355 = Call <()> traceRelease t347
        ; *ast.CallExpr @ 4580:4 is t355
        Jump → b20

--- FAIL: TestStdlib (2.15s)
panic: SanityCheck failed [recovered]
        panic: SanityCheck failed

goroutine 18 [running]:
testing.tRunner.func1.2({0x6f37c0, 0x7d1f30})
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/testing/testing.go:1634 +0x377
panic({0x6f37c0?, 0x7d1f30?})
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/runtime/panic.go:770 +0x132
honnef.co/go/tools/go/ir.mustSanityCheck(0xc01a4a8500, {0x0?, 0x0?})
        /home/kachick/repos/go-tools/go/ir/sanity.go:47 +0x9a
honnef.co/go/tools/go/ir.(*Function).finishBody(0xc01a4a8500)
        /home/kachick/repos/go-tools/go/ir/func.go:567 +0x35d
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc01a4a8500)
        /home/kachick/repos/go-tools/go/ir/builder.go:2514 +0x4b2
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019391cc0)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019391cc0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019678640)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019678640)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019678280)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019678280)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc0193c1a40)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc0193c1a40)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc01932c8c0)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc01932c8c0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc01932c640)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc01932c640)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc01932db80)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc01932db80)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019621180)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019621180)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019076780)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019076780)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc020f9cdc0)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc020f9cdc0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).expr0(0xc0209758f0, 0xc0190763c0, {0x7d4dd8?, 0xc001617100}, {0x7, {0x7d4210, 0xc0
        /home/kachick/repos/go-tools/go/ir/builder.go:584 +0xa8b
honnef.co/go/tools/go/ir.(*builder).expr(0xc0209758f0, 0xc0190763c0, {0x7d4dd8, 0xc001617100})
        /home/kachick/repos/go-tools/go/ir/builder.go:559 +0x20c
honnef.co/go/tools/go/ir.(*builder).emitCallArgs(0xc0211f58f0, 0xc0190763c0, 0xc003f68140, 0xc001a66240, {0x0?, 0x0, 0
        /home/kachick/repos/go-tools/go/ir/builder.go:964 +0x115
honnef.co/go/tools/go/ir.(*builder).setCall(0xc0209758f0, 0xc0190763c0, 0xc001a66240, 0xc0210c6738)
        /home/kachick/repos/go-tools/go/ir/builder.go:1025 +0x8d
honnef.co/go/tools/go/ir.(*builder).expr0(0xc0209758f0, 0xc0190763c0, {0x7d4538?, 0xc001a66240}, {0x1, {0x7d41e8, 0x0}
        /home/kachick/repos/go-tools/go/ir/builder.go:616 +0x21de
honnef.co/go/tools/go/ir.(*builder).expr(0xc0209758f0, 0xc0190763c0, {0x7d4538, 0xc001a66240})
        /home/kachick/repos/go-tools/go/ir/builder.go:559 +0x20c
honnef.co/go/tools/go/ir.(*builder).stmt(0xc0209758f0, 0xc0190763c0, {0x7d4aa8?, 0xc001617120?})
        /home/kachick/repos/go-tools/go/ir/builder.go:2278 +0x129
honnef.co/go/tools/go/ir.(*builder).stmtList(...)
        /home/kachick/repos/go-tools/go/ir/builder.go:847
honnef.co/go/tools/go/ir.(*builder).stmt(0xc0211f58f0, 0xc0190763c0, {0x7d49e8?, 0xc001b0de00?})
        /home/kachick/repos/go-tools/go/ir/builder.go:2385 +0x1447
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc0190763c0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2497 +0x417
honnef.co/go/tools/go/ir.(*builder).buildExits(0xc0211f58f0, 0xc019049a40)
        /home/kachick/repos/go-tools/go/ir/exits.go:214 +0x13a5
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc0211f58f0, 0xc019049a40)
        /home/kachick/repos/go-tools/go/ir/builder.go:2512 +0x48e
honnef.co/go/tools/go/ir.(*builder).buildFuncDecl(0xc0209758f0, 0xc0015414d0, 0xc001b0d0e0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2534 +0x189
honnef.co/go/tools/go/ir.(*Package).build(0xc0015414d0)
        /home/kachick/repos/go-tools/go/ir/builder.go:2638 +0xb46
sync.(*Once).doSlow(0xc02c023ce0?, 0xc00f09d7a0?)
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/sync/once.go:65
honnef.co/go/tools/go/ir.(*Package).Build(...)
        /home/kachick/repos/go-tools/go/ir/builder.go:2556
command-line-arguments_test.TestStdlib(0xc00014c680)
        /home/kachick/repos/go-tools/go/ir/stdlib_test.go:93 +0x36e
testing.tRunner(0xc00014c680, 0x7734e0)
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /nix/store/v2hwzp398da6s8vwgckf59xxx0va00pc-go-1.22.0/share/go/src/testing/testing.go:1742 +0x390
FAIL    command-line-arguments  2.169s
FAIL
```
</details>

## May fix?

- #1495
- #1496

## Related

- Since golang/go#56010
- Referenced https://github.com/golang/tools/commit/992d98451cb0cd4370c14e54e4262be89e83bfe2